### PR TITLE
Fix S25FL1D_ReadJedecId

### DIFF
--- a/FreeRTOS/Demo/CORTEX_M7_SAMV71_Xplained_IAR_Keil/libboard_samv7-ek/source/s25fl1.c
+++ b/FreeRTOS/Demo/CORTEX_M7_SAMV71_Xplained_IAR_Keil/libboard_samv7-ek/source/s25fl1.c
@@ -260,7 +260,7 @@ unsigned int S25FL1D_ReadJedecId(void)
     pDev->DataSize = 3;
     S25FL1D_SendCommand(READ_JEDEC_ID, READ_DEV);
 
-    id = ( (pDev->pData[0] << 16)  || (pDev->pData[1] << 8) || (pDev->pData[2]));
+    id = ( (pDev->pData[0] << 16)  | (pDev->pData[1] << 8) | (pDev->pData[2]));
 
     return id;
 }


### PR DESCRIPTION
Function was assigning the result of a boolean opeartion to id intead of the bitwise operation